### PR TITLE
Gyro and Odometry

### DIFF
--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -15,6 +15,8 @@ public class OI {
     private static class Bindings {
         /** Example button */
         static final Button EXAMPLE_BUTTON = XboxController.Button.kA;
+        /** Button to re-zero gyro */
+        static final Button ZERO_GYRO = XboxController.Button.kBack;
     }
 
     /** Port for controller used by driver */
@@ -29,4 +31,6 @@ public class OI {
 
     /** Example button. Mapped to {@link Bindings#EXAMPLE_BUTTON} */
     public static final JoystickButton exampleButton = new JoystickButton(driverController, Bindings.EXAMPLE_BUTTON.value);
+    /** Example button. Mapped to {@link Bindings#ZERO_GYRO} */
+    public static final JoystickButton zeroButton = new JoystickButton(driverController, Bindings.ZERO_GYRO.value);
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -38,7 +38,8 @@ public class RobotContainer {
   /** Initialise the container for the robot. Contains subsystems, OI devices, and commands. */
   public static void init() {
     drivetrain.setDefaultCommand(new DriveCommand(drivetrain));
-
+    // Initialise gyro to be forward-facing
+    gyro.setCurrentYaw(0);
     // Configure the button bindings
     configureButtonBindings();
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -50,7 +50,10 @@ public class RobotContainer {
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
-  private static void configureButtonBindings() {}
+  private static void configureButtonBindings() {
+    // TODO: Disable binding for competition use
+    OI.zeroButton.whenPressed(() -> gyro.setCurrentYaw(0));
+  }
 
   /**
    * Use this to pass the autonomous command to the main {@link Robot} class.

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -146,7 +146,7 @@ public class Drivetrain extends SubsystemBase {
         rotation *= 2.0 / Math.hypot(WHEELBASE_METERS, TRACKWIDTH_METERS);
         if (fieldOriented) {
             m_chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(translation.getX(), translation.getY(), rotation,
-                Rotation2d.fromDegrees(360.0 - RobotContainer.gyro.getYaw()));
+                Rotation2d.fromDegrees(RobotContainer.gyro.getYaw()));
         } else {
             m_chassisSpeeds = new ChassisSpeeds(translation.getX(), translation.getY(), rotation);
         }

--- a/src/main/java/frc/robot/subsystems/Gyro.java
+++ b/src/main/java/frc/robot/subsystems/Gyro.java
@@ -7,6 +7,7 @@ package frc.robot.subsystems;
 // libraries needed for NavX
 import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.SPI;
+import edu.wpi.first.wpilibj.SerialPort.Port;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
@@ -29,7 +30,8 @@ public class Gyro extends SubsystemBase {
 
   /** Creates a new Gyro. */
   public Gyro() {
-    gyro = new AHRS(SPI.Port.kMXP);
+    gyro = new AHRS(Port.kUSB);
+    gyro.calibrate();
     gyro.reset();
     initializeShuffleboard();
   }

--- a/src/main/java/frc/robot/subsystems/Gyro.java
+++ b/src/main/java/frc/robot/subsystems/Gyro.java
@@ -24,6 +24,9 @@ public class Gyro extends SubsystemBase {
   // make our gyro object
   AHRS gyro;
 
+  // Offset angle to allow for starting in various orientations
+  private double m_offset = 0;
+
   /** Creates a new Gyro. */
   public Gyro() {
     gyro = new AHRS(SPI.Port.kMXP);
@@ -44,7 +47,7 @@ public class Gyro extends SubsystemBase {
    */
   public double getYaw() {
     // Flip angle since gyro is mounted upside down
-    double raw = 360-gyro.getYaw();
+    double raw = 360-gyro.getYaw() + m_offset;
     return raw > 180 ? raw - 360 : raw;
   }
 
@@ -62,6 +65,14 @@ public class Gyro extends SubsystemBase {
    */
   public void resetGyro() {
     gyro.reset();
+  }
+
+  /**
+   * Set the current direction to correspond to a given yaw value
+   * @param yaw Yaw value in degrees (-180 to 180)
+   */
+  public void setCurrentYaw(double yaw){
+    m_offset = yaw - getYaw() + m_offset;
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/SwerveOdometry.java
+++ b/src/main/java/frc/robot/subsystems/SwerveOdometry.java
@@ -107,7 +107,7 @@ public class SwerveOdometry extends SubsystemBase {
 
   /** return robot's current position vector Pose2d */
   public Pose2d getPose2d() {
-    return m_odometry.getPoseMeters();
+    return new Pose2d(getX(), getY(), new Rotation2d(getAngle() * DEGtoRAD));
   }
 
   /** Return current odometry x displacement (in m) */

--- a/src/main/java/frc/robot/subsystems/SwerveOdometry.java
+++ b/src/main/java/frc/robot/subsystems/SwerveOdometry.java
@@ -88,7 +88,7 @@ public class SwerveOdometry extends SubsystemBase {
   public void periodic() {
 
     // get gyro angle (in degrees) and make rotation vector
-    Rotation2d gyroangle = new Rotation2d(RobotContainer.gyro.getYaw() * DEGtoRAD);
+    Rotation2d gyroangle = new Rotation2d((RobotContainer.gyro.getYaw() + 90) * DEGtoRAD);
 
     // get states of all swerve modules from subsystem
     SwerveModuleState[] states = RobotContainer.drivetrain.getSwerveStates();
@@ -117,12 +117,12 @@ public class SwerveOdometry extends SubsystemBase {
 
   /** Return current odometry y displacement (in m) */
   public double getY() {
-    return m_odometry.getPoseMeters().getY();
+    return -m_odometry.getPoseMeters().getY();
   }
 
   // return current odometry angle (in deg)
   public double getAngle() {
-    return m_odometry.getPoseMeters().getRotation().getDegrees();
+    return m_odometry.getPoseMeters().getRotation().getDegrees() - 90;
   }
 
 


### PR DESCRIPTION
# Changes

Fix issues with gyro initialisation, make it possible to specify starting angle or reset at runtime.
Also includes adjustments to odometry to match [field coordinate system](https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#field-coordinate-system)

Closes #41
Contributes to #46, not sure if it's enough to close

### Subystems
 - Gyro
 - SwerveOdometry

### Commands
N/A

# Testing
 - [x] Robot starts at specified angle
 - [x] Angle can be set with a button press 
 - [x] Robot behaves correctly after angle is set
 - [x] Left is positive angle
 - [x] Down the field is positive y
 - [x] Left (from driver station) is positive x